### PR TITLE
Rename css class 'tooltip' to 'histogramtooltip'.

### DIFF
--- a/bootstrap.histogram.slider.css
+++ b/bootstrap.histogram.slider.css
@@ -176,10 +176,10 @@
 .slider input {
   display: none;
 }
-.slider .histogramtooltip.top {
+.slider .tooltip.top {
   margin-top: -36px;
 }
-.slider .histogramtooltip-inner {
+.slider .tooltip-inner {
   white-space: nowrap;
   max-width: none;
 }

--- a/bootstrap.histogram.slider.css
+++ b/bootstrap.histogram.slider.css
@@ -176,10 +176,10 @@
 .slider input {
   display: none;
 }
-.slider .tooltip.top {
+.slider .histogramtooltip.top {
   margin-top: -36px;
 }
-.slider .tooltip-inner {
+.slider .histogramtooltip-inner {
   white-space: nowrap;
   max-width: none;
 }

--- a/bootstrap.histogram.slider.js
+++ b/bootstrap.histogram.slider.js
@@ -128,7 +128,7 @@
                     inRangeOffset = parseInt(self.options.height - height),
                     outRangeOffset = -parseInt(self.options.height - height * 2);
 
-                var binHtml = "<div class='tooltip' style='float:left!important;width:" + widthPerBin + "%;'>" +
+                var binHtml = "<div class='histogramtooltip' style='float:left!important;width:" + widthPerBin + "%;'>" +
                     toolTipHtml +
                     "<div class='bin in-range " + inRangeClass + "' style='height:" + height + "px;bottom:-" + inRangeOffset + "px;position: relative;'></div>" +
                     "<div class='bin out-of-range " + outRangeClass + "' style='height:" + height + "px;bottom:" + outRangeOffset + "px;position: relative;'></div>" +

--- a/histogram.slider.css
+++ b/histogram.slider.css
@@ -23,7 +23,7 @@
      border-radius: 0;
  }
 
- .tooltip > .tooltiptext {
+ .histogramtooltip > .tooltiptext {
      visibility: hidden;
      width: 120px;
      background-color: #FFFFCA;
@@ -34,7 +34,7 @@
      z-index: 100;
  }
 
- .tooltip:hover > .tooltiptext {
+ .histogramtooltip:hover > .tooltiptext {
      visibility: visible;
      margin-top: 50px;
  }

--- a/histogram.slider.js
+++ b/histogram.slider.js
@@ -128,7 +128,7 @@
                     inRangeOffset = parseInt(self.options.height - height),
                     outRangeOffset = -parseInt(self.options.height - height * 2);
 
-                var binHtml = "<div class='tooltip' style='float:left!important;width:" + widthPerBin + "%;'>" +
+                var binHtml = "<div class='histogramtooltip' style='float:left!important;width:" + widthPerBin + "%;'>" +
                     toolTipHtml +
                     "<div class='bin in-range " + inRangeClass + "' style='height:" + height + "px;bottom:-" + inRangeOffset + "px;position: relative;'></div>" +
                     "<div class='bin out-of-range " + outRangeClass + "' style='height:" + height + "px;bottom:" + outRangeOffset + "px;position: relative;'></div>" +


### PR DESCRIPTION
This makes it possible to use the normal bootstrap.css in the same document (Tested with version 3.3.7).